### PR TITLE
Remove extra check_headers, replace spaces with tabs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,44 +60,39 @@ check_headers:
 
 .PHONY: build_app
 build_app:
-        docker run --rm --mount type=bind,source="$$(pwd)"/containers,target=/gosrc -w /gosrc golang:1.10.3 go build -v -o app
+	docker run --rm --mount type=bind,source="$$(pwd)"/containers,target=/gosrc -w /gosrc golang:1.10.3 go build -v -o app
 
 .PHONY: build_root_image
 build_root_image:
-        cd containers && docker build -t hello-run-as-root:1.0.0 -f root_Dockerfile .
+	cd containers && docker build -t hello-run-as-root:1.0.0 -f root_Dockerfile .
 
 .PHONY: build_user_image
 build_user_image:
-        cd containers && docker build -t hello-run-as-user:1.0.0 -f user_Dockerfile .
+	cd containers && docker build -t hello-run-as-user:1.0.0 -f user_Dockerfile .
 
 .PHONY: push_root_image
 push_root_image:
-        docker tag hello-run-as-root:1.0.0 gcr.io/"$$(gcloud config get-value project)"/hello-run-as-root:1.0.0
-        docker push gcr.io/"$$(gcloud config get-value project)"/hello-run-as-root:1.0.0
+	docker tag hello-run-as-root:1.0.0 gcr.io/"$$(gcloud config get-value project)"/hello-run-as-root:1.0.0
+	docker push gcr.io/"$$(gcloud config get-value project)"/hello-run-as-root:1.0.0
 
 .PHONY: push_user_image
 push_user_image:
-        docker tag hello-run-as-user:1.0.0 gcr.io/"$$(gcloud config get-value project)"/hello-run-as-user:1.0.0
-        docker push gcr.io/"$$(gcloud config get-value project)"/hello-run-as-user:1.0.0
-
-.PHONY: check_headers
-check_headers:
-        @echo "Checking file headers"
-        @python test/verify_boilerplate.py
+	docker tag hello-run-as-user:1.0.0 gcr.io/"$$(gcloud config get-value project)"/hello-run-as-user:1.0.0
+	docker push gcr.io/"$$(gcloud config get-value project)"/hello-run-as-user:1.0.0
 
 .PHONY: setup-project
 setup-project:
-        # Enables the Google Cloud APIs needed
-        ./enable-apis.sh
-        # Runs generate-tfvars.sh
-        ./generate-tfvars.sh
+	# Enables the Google Cloud APIs needed
+	./enable-apis.sh
+	# Runs generate-tfvars.sh
+	./generate-tfvars.sh
 
 .PHONY: tf-apply
 tf-apply:
-        # Downloads the terraform providers and applies the configuration
-        cd terraform && terraform init && terraform apply
+	# Downloads the terraform providers and applies the configuration
+	cd terraform && terraform init && terraform apply
 
 .PHONY: tf-destroy
 tf-destroy:
-        # Downloads the terraform providers and applies the configuration
-        cd terraform && terraform destroy
+	# Downloads the terraform providers and applies the configuration
+	cd terraform && terraform destroy


### PR DESCRIPTION
As it currently stands, the syntax problems cause this error when you run `make ...`:
```
Makefile:75: *** multiple target patterns.  Stop.
```